### PR TITLE
Add comments about the build-docker-image command

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Smile Internal Action: Build Docker Image
 
-Smile Internal Github Action to build a docker image.
+Smile Internal Github Action to build a docker image and push it to a given registry.
 
 _Note:_ This action is _NOT_ intended for use outside of Smile, and no support will be offered for such use. External pull requests will _not_ be accepted.
 

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,8 @@ runs:
     - name: Build and Upload Docker Image
       id: build-docker
       shell: bash
+      # Note: The build-docker-image script is provided by gruntworks https://github.com/gruntwork-io/terraform-aws-ci/tree/master/modules/build-helpers,
+      #       and it also pushes to the given repo with the given tag
       run: build-docker-image
               --docker-image-name "${{ inputs.docker_repo_url }}"
               --docker-image-tag "${{ inputs.tag_prefix}}${{ github.sha }}"


### PR DESCRIPTION
As it was not clear this GH Action builds and pushes a image to given registry, some comments were added to make it clear