### PR TITLE
Update to use checkout V3 and $GITHUB_OUTPUT env var.

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Build and Upload Docker Image
       id: build-docker
       shell: bash
@@ -33,5 +33,5 @@ runs:
       id: record_image
       shell: bash
       run: |
-        echo "::set-output name=image::${{ inputs.docker_repo_url }}:${{ inputs.tag_prefix }}${{ github.sha }}"
-        echo "::set-output name=tag::${{ inputs.tag_prefix }}${{ github.sha }}"
+        echo "image=${{ inputs.docker_repo_url }}:${{ inputs.tag_prefix }}${{ github.sha }}" >> $GITHUB_OUTPUT
+        echo "tag=${{ inputs.tag_prefix }}${{ github.sha }}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Removes usage of the old way of setting outputs by echoing "::set-output", which has been deprecated.